### PR TITLE
Allow local configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ npm-debug.log
 # secrets files as long as you replace their contents by environment
 # variables.
 /config/*.secret.exs
+/config/local.exs

--- a/config/config.exs
+++ b/config/config.exs
@@ -29,3 +29,6 @@ config :we_need_to_watch, :basic_auth,
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env}.exs"
+
+# Override with local configuration (gitignored)
+import_config "local.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -31,4 +31,4 @@ config :we_need_to_watch, :basic_auth,
 import_config "#{Mix.env}.exs"
 
 # Override with local configuration (gitignored)
-import_config "local.exs"
+if File.exists?("./config/local.exs"), do: import_config "local.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -51,7 +51,7 @@ config :phoenix, :stacktrace_depth, 20
 # Configure your database
 config :we_need_to_watch, WeNeedToWatch.Repo,
   adapter: Ecto.Adapters.Postgres,
-  username: "raelyn",
+  username: "postgres",
   database: "we_need_to_watch_dev",
   hostname: "localhost",
   pool_size: 10

--- a/config/local.exs.example
+++ b/config/local.exs.example
@@ -1,0 +1,8 @@
+use Mix.Config
+
+config :we_need_to_watch, WeNeedToWatch.Repo,
+  adapter: Ecto.Adapters.Postgres,
+  username: "user",
+  password: "password",
+  hostname: "localhost"
+


### PR DESCRIPTION
Users are going to have different usernames, different passwords, different database setups. By having an untracked `config/local.exs`, we can allow users to override settings without having to change version-controlled files like `config/dev.exs`.

I've also added a `config/local.exs.example` that can be copied over to start configuring an install.